### PR TITLE
Fix whitelist behavior

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -1,5 +1,6 @@
 var util = require('util');
-var AWS = require('aws-sdk');
+var AWS_SDK = require('aws-sdk');
+var AWS = undefined;
 
 function CloudwatchBackend(startupTime, config, emitter) {
   var self = this;
@@ -234,7 +235,8 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   this.batchSend(currentSetMetrics, namespace);
 };
 
-exports.init = function(startupTime, config, events) {
+exports.init = function(startupTime, config, events, aws) {
+  AWS = aws || AWS_SDK;
   var cloudwatch = config.cloudwatch || {};
   var instances = cloudwatch.instances || [cloudwatch];
   for (key in instances) {

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -49,7 +49,7 @@ CloudwatchBackend.prototype.processKey = function(key) {
 };
 
 CloudwatchBackend.prototype.isBlacklisted = function(key) {
-
+  var blacklist = this.activeBlacklist();
   var blacklisted = false;
 
   // First check if key is whitelisted
@@ -58,16 +58,28 @@ CloudwatchBackend.prototype.isBlacklisted = function(key) {
       return false;
   }
 
-  if (this.config.blacklist && this.config.blacklist.length > 0) {
-    for (var i = 0; i < this.config.blacklist.length; i++) {
-      if (key.indexOf(this.config.blacklist[i]) >= 0) {
-        blacklisted = true;
-        break;
-      }
+  for (var i = 0; i < blacklist.length; i++) {
+    if (key.indexOf(blacklist[i]) >= 0) {
+      blacklisted = true;
+      break;
     }
   }
   return blacklisted;
 };
+
+CloudwatchBackend.prototype.activeBlacklist = function() {
+  if (this.config.blacklist && this.config.blacklist.length > 0) {
+    // return user-configured blacklist if available
+    return this.config.blacklist;
+  } else if (this.config.whitelist && this.config.whitelist.length > 0) {
+    // if user configured a whitelist but no blacklist, that implies
+    // blacklisting everything not explicitly whitelisted
+    return [''];
+  } else {
+    // if neither list was configured, the default blocklist is empty
+    return [];
+  }
+}
 
 CloudwatchBackend.prototype.chunk = function(arr, chunkSize) {
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,16 @@
   "dependencies": {
     "aws-sdk": "~2.0.15"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "~3.5.0",
+    "mocha": "~3.3.0",
+    "sinon": "~2.1.0",
+    "sinon-chai": "~2.10.0"
+  },
   "optionalDependencies": {},
+  "scripts": {
+    "test": "mocha"
+  },
   "engines": {
     "node": "*"
   },
@@ -22,6 +30,6 @@
     "aws",
     "amazon",
     "cloudwatchappender"
-  ], 
+  ],
   "license": {"type": "MIT", "url": "https://github.com/camitz/aws-cloudwatch-statsd-backend/blob/master/LICENSE.md"}
 }

--- a/test/aws-cloudwatch-statsd-backend-test.js
+++ b/test/aws-cloudwatch-statsd-backend-test.js
@@ -1,0 +1,164 @@
+var backendInit = require('../lib/aws-cloudwatch-statsd-backend.js').init;
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
+describe('cloudwatch-backend', function() {
+  beforeEach(function() {
+    console = sinon.spy();
+  });
+
+  describe('no explicit whitelist or blacklist', function() {
+    it('emits metrics when no white/blacklist specified', function() {
+      var aws = stubAWS();
+      var emitter = new MockEmitter();
+
+      backendInit(0, basicConfig(), emitter, aws);
+      emitter.flush(1, {
+        counters: { 'my.metric': 42 },
+        gauges: {},
+        timers: {},
+        sets: {},
+      });
+
+      expect(aws.CloudWatch().putMetricData).to.have.been.calledOnce;
+      expect(aws.CloudWatch().putMetricData).to.have.been.calledWithMatch({
+        MetricData: [
+          {
+            MetricName: 'my.metric',
+            Unit: 'Count',
+            Timestamp: tsToDate(1),
+            Value: 42
+          }
+        ],
+        Namespace: 'AwsCloudWatchStatsdBackend'
+      }, sinon.match.func);
+    });
+
+    it('respects the blacklist', function() {
+      var aws = stubAWS();
+      var emitter = new MockEmitter();
+      var config = basicConfig();
+
+      config.cloudwatch.blacklist = ['my.metric'];
+
+      backendInit(0, config, emitter, aws);
+      emitter.flush(1, {
+        counters: { 'my.metric': 42 },
+        gauges: {},
+        timers: {},
+        sets: {},
+      });
+
+      expect(aws.CloudWatch().putMetricData).to.have.been.calledNever;
+    });
+
+    // red test right now
+    it('respects the whitelist, which implies blacklist', function() {
+      var aws = stubAWS();
+      var emitter = new MockEmitter();
+      var config = basicConfig();
+
+      config.cloudwatch.whitelist = ['my.metric'];
+
+      backendInit(0, config, emitter, aws);
+      emitter.flush(1, {
+        counters: { 'my.metric': 42, 'my.other': 99 },
+        gauges: {},
+        timers: {},
+        sets: {},
+      });
+
+      expect(aws.CloudWatch().putMetricData).to.have.been.calledOnce;
+      expect(aws.CloudWatch().putMetricData).to.have.been.calledWithMatch({
+        MetricData: [
+          {
+            MetricName: 'my.metric',
+            Unit: 'Count',
+            Timestamp: tsToDate(1),
+            Value: 42
+          }
+        ],
+        Namespace: 'AwsCloudWatchStatsdBackend'
+      }, sinon.match.func);
+    });
+
+    it('when whitelist & blacklist conflict, whitelist wins', function() {
+      var aws = stubAWS();
+      var emitter = new MockEmitter();
+      var config = basicConfig();
+
+      config.cloudwatch.whitelist = ['my.metric'];
+      config.cloudwatch.blacklist = ['my.metric', 'my.other'];
+
+      backendInit(0, config, emitter, aws);
+      emitter.flush(1, {
+        counters: { 'my.metric': 42, 'my.other': 99 },
+        gauges: {},
+        timers: {},
+        sets: {},
+      });
+
+      expect(aws.CloudWatch().putMetricData).to.have.been.calledOnce;
+      expect(aws.CloudWatch().putMetricData).to.have.been.calledWithMatch({
+        MetricData: [
+          {
+            MetricName: 'my.metric',
+            Unit: 'Count',
+            Timestamp: tsToDate(1),
+            Value: 42
+          }
+        ],
+        Namespace: 'AwsCloudWatchStatsdBackend'
+      }, sinon.match.func);
+    });
+  });
+
+  function stubAWS() {
+    return {
+      CloudWatch: sinon.stub().returns({
+        putMetricData: sinon.spy()
+      }),
+      Credentials: sinon.spy(),
+      EC2MetadataCredentials: sinon.stub().returns({
+        refresh: function(cb) {
+          cb.apply(null, []);
+        },
+        request: function(cb) {
+          throw "this path isn't stubbed yet";
+        }
+      }),
+    };
+  }
+
+  function MockEmitter() {
+    this.handlers = {};
+  }
+
+  MockEmitter.prototype.on = function(evName, cb) {
+    this.handlers[evName] = this.handlers[evName] || [];
+    this.handlers[evName].push(cb);
+  };
+
+  MockEmitter.prototype.flush = function(timestamp, metrics) {
+    for (var i = 0; i < this.handlers.flush.length; i++) {
+      this.handlers.flush[i].apply(this, [timestamp, metrics]);
+    }
+  }
+
+  function tsToDate(timestamp) {
+    return new Date(timestamp * 1000).toISOString();
+  }
+
+  function basicConfig() {
+    return {
+      cloudwatch: {
+        iamRole: 'any',
+        region: 'us-east-1'
+      }
+    };
+  }
+});

--- a/test/aws-cloudwatch-statsd-backend-test.js
+++ b/test/aws-cloudwatch-statsd-backend-test.js
@@ -56,7 +56,6 @@ describe('cloudwatch-backend', function() {
       expect(aws.CloudWatch().putMetricData).to.have.been.calledNever;
     });
 
-    // red test right now
     it('respects the whitelist, which implies blacklist', function() {
       var aws = stubAWS();
       var emitter = new MockEmitter();


### PR DESCRIPTION
The README's description of how to configure an exclusive whitelist did not
reflect reality: if you *only* configured a whitelist, then anything not in
the whitelist would fall through to the typical blacklist logic, which by
default lets everything through if you didn't actually configure a
blacklist.

My first step here was to add a test suite to get more confidence about the
behavior and the change, and then to change the behavior and fix the red test.