### PR TITLE
Improve logging

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -2,11 +2,13 @@ var util = require('util');
 var AWS_SDK = require('aws-sdk');
 var AWS = undefined;
 
-function CloudwatchBackend(startupTime, config, emitter) {
+function CloudwatchBackend(startupTime, config, emitter, logger) {
   var self = this;
 
   this.config = config || {};
   AWS.config = this.config;
+
+  this.logger = logger;
 
   function setEmitter() {
     self.cloudwatch = new AWS.CloudWatch(self.config);
@@ -19,7 +21,9 @@ function CloudwatchBackend(startupTime, config, emitter) {
       // If the iamRole is set to any, then attempt to fetch any available credentials
       ms = new AWS.EC2MetadataCredentials();
       ms.refresh(function(err) {
-        if (err) { console.log('Failed to fetch IAM role credentials: ' + err); }
+        if (err) {
+          self.logger.log('Failed to fetch IAM role credentials: ' + err, 'ERROR');
+        }
         self.config.credentials = ms;
         setEmitter();
       });
@@ -29,7 +33,9 @@ function CloudwatchBackend(startupTime, config, emitter) {
       ms.request('/latest/meta-data/iam/security-credentials/' + this.config.iamRole, function(err, rdata) {
         var data = JSON.parse(rdata);
 
-        if (err) { console.log('Failed to fetch IAM role credentials: ' + err); }
+        if (err) {
+          self.logger.log('Failed to fetch IAM role credentials: ' + err, 'ERROR');
+        }
         self.config.credentials = new AWS.Credentials(data.AccessKeyId, data.SecretAccessKey, data.Token);
         setEmitter();
       });
@@ -54,7 +60,7 @@ CloudwatchBackend.prototype.isBlacklisted = function(key) {
 
   // First check if key is whitelisted
   if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) >= 0) {
-      // console.log("Key (counter) " + key + " is whitelisted");
+      this.logger.log('Key (counter) ' + key + ' is whitelisted', 'DEBUG');
       return false;
   }
 
@@ -106,10 +112,10 @@ CloudwatchBackend.prototype.batchSend = function(currentMetricsBatch, namespace)
       }, function(err, data) {
         if (err) {
           // log an error
-          console.log(util.inspect(err));
+          this.logger.log(util.inspect(err), 'ERROR');
         } else {
           // Success
-          // console.log(util.inspect(data));
+          this.logger.log(util.inspect(data), 'DEBUG');
         }
       });
     }
@@ -117,8 +123,7 @@ CloudwatchBackend.prototype.batchSend = function(currentMetricsBatch, namespace)
 };
 
 CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
-
-  console.log('Flushing metrics at ' + new Date(timestamp * 1000).toISOString());
+  this.logger.log('Flushing metrics at ' + new Date(timestamp * 1000).toISOString(), 'INFO');
 
   var counters = metrics.counters;
   var gauges = metrics.gauges;
@@ -247,14 +252,14 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   this.batchSend(currentSetMetrics, namespace);
 };
 
-exports.init = function(startupTime, config, events, _logger, aws) {
+exports.init = function(startupTime, config, events, logger, aws) {
   AWS = aws || AWS_SDK;
   var cloudwatch = config.cloudwatch || {};
   var instances = cloudwatch.instances || [cloudwatch];
   for (key in instances) {
     instanceConfig = instances[key];
-    console.log("Starting cloudwatch reporter instance in region:", instanceConfig.region);
-    var instance = new CloudwatchBackend(startupTime, instanceConfig, events);
+    logger.log('Starting cloudwatch reporter instance in region: ' + instanceConfig.region, 'INFO');
+    var instance = new CloudwatchBackend(startupTime, instanceConfig, events, logger);
   }
   return true;
 };

--- a/test/aws-cloudwatch-statsd-backend-test.js
+++ b/test/aws-cloudwatch-statsd-backend-test.js
@@ -16,7 +16,7 @@ describe('cloudwatch-backend', function() {
       var aws = stubAWS();
       var emitter = new MockEmitter();
 
-      backendInit(0, basicConfig(), emitter, null, aws);
+      backendInit(0, basicConfig(), emitter, logger(), aws);
       emitter.flush(1, {
         counters: { 'my.metric': 42 },
         gauges: {},
@@ -45,7 +45,7 @@ describe('cloudwatch-backend', function() {
 
       config.cloudwatch.blacklist = ['my.metric'];
 
-      backendInit(0, config, emitter, null, aws);
+      backendInit(0, config, emitter, logger(), aws);
       emitter.flush(1, {
         counters: { 'my.metric': 42 },
         gauges: {},
@@ -63,7 +63,7 @@ describe('cloudwatch-backend', function() {
 
       config.cloudwatch.whitelist = ['my.metric'];
 
-      backendInit(0, config, emitter, null, aws);
+      backendInit(0, config, emitter, logger(), aws);
       emitter.flush(1, {
         counters: { 'my.metric': 42, 'my.other': 99 },
         gauges: {},
@@ -93,7 +93,7 @@ describe('cloudwatch-backend', function() {
       config.cloudwatch.whitelist = ['my.metric'];
       config.cloudwatch.blacklist = ['my.metric', 'my.other'];
 
-      backendInit(0, config, emitter, null, aws);
+      backendInit(0, config, emitter, logger(), aws);
       emitter.flush(1, {
         counters: { 'my.metric': 42, 'my.other': 99 },
         gauges: {},
@@ -124,7 +124,7 @@ describe('cloudwatch-backend', function() {
       Credentials: sinon.spy(),
       EC2MetadataCredentials: sinon.stub().returns({
         refresh: function(cb) {
-          cb.apply(null, []);
+          cb.apply(logger(), []);
         },
         request: function(cb) {
           throw "this path isn't stubbed yet";
@@ -159,5 +159,9 @@ describe('cloudwatch-backend', function() {
         region: 'us-east-1'
       }
     };
+  }
+
+  function logger() {
+    return { log: sinon.spy() };
   }
 });


### PR DESCRIPTION
Rather than just using `console.log`, use the [`Logger`][1] provided by
statsd to get appropriate filtering based on configured logging level.

[1]: https://github.com/etsy/statsd/blob/v0.7.2/lib/logger.js